### PR TITLE
hotfix/fix matching reviewer

### DIFF
--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -98,9 +98,11 @@ module.exports = {
     const messagePostedBy = userId;
     const messagePostDate = new Date();
     const user = await User.findById(userId);
-    const userLanguageLevel = user.languages[language]
-      ? user.languages[language].level
-      : 0;
+    const languageIndex = user.languages.findIndex(
+      (item) => item.language === language
+    );
+    const userLanguageLevel =
+      languageIndex >= 0 ? user.languages[languageIndex].level : 0;
     const newReview = new Review({
       title,
       language,


### PR DESCRIPTION
Initially, new reviews that were created always had language level of 0. This PR made sure new reviews has the correct language level to be used to match with new reviewers.